### PR TITLE
Making https optional

### DIFF
--- a/src/Drivers/IpStackDriver.php
+++ b/src/Drivers/IpStackDriver.php
@@ -74,6 +74,12 @@ class IpStackDriver extends AbstractGeoIPDriver
      */
     protected function getUrl($ip)
     {
-        return 'https://api.ipstack.com/'.$ip.'?access_key='.array_get($this->config, 'key');
+        $protocol = 'https';
+
+        if (!empty(array_get($this->config, 'http'))) {
+            $protocol = 'http';
+        }
+
+        return $protocol.'://api.ipstack.com/'.$ip.'?access_key='.array_get($this->config, 'key');
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -33,6 +33,7 @@ return [
         |
         */
         'key' => env('GEOIP_IPSTACK_KEY'),
+        'http' => env('GEOIP_IPSTACK_HTTP', false),
     ],
 
     /*


### PR DESCRIPTION
I needed to access IPStack using the http protocol rather than the paid https protocol.

This PR adds an optional http param to the config, failing safe to https.