### PR TITLE
Updates guzzle request options

### DIFF
--- a/src/GeoIPUpdater.php
+++ b/src/GeoIPUpdater.php
@@ -71,7 +71,7 @@ class GeoIPUpdater
         try {
             // Download database temp dir
             $tempFile = $tempDir.'/geoip';
-            $this->guzzle->get($maxmindDatabaseUrl, ['save_to' => $tempFile.'.tar.gz']);
+            $this->guzzle->get($maxmindDatabaseUrl, ['sink' => $tempFile.'.tar.gz']);
 
             $p = new PharData($tempFile.'.tar.gz');
             $p->decompress();


### PR DESCRIPTION
Request options save_to has been replaced by sink and removed in Guzzle 7.0