### PR TITLE
Add ip2geo driver

### DIFF
--- a/config/ip-geolocation.php
+++ b/config/ip-geolocation.php
@@ -6,7 +6,7 @@ return [
     | IPGeolocation Driver Type
     |--------------------------------------------------------------------------
     |
-    | Supported: "ip-api", "maxmind_database", "maxmind_api", "ipstack", "ipquery"
+    | Supported: "ip-api", "maxmind_database", "maxmind_api", "ipstack", "ipquery", "ip2geo"
     |
     */
     'driver' => env('IPGEOLOCATION_DRIVER', 'ip-api'),
@@ -94,5 +94,15 @@ return [
     'ipquery' => [
         // Get your API key here: https://ipquery.io
         'key' => env('IPGEOLOCATION_IPQUERY_KEY'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | ip2geo Driver
+    |--------------------------------------------------------------------------
+    */
+    'ip2geo' => [
+        // Get your API key here: https://ip2geo.dev
+        'key' => env('IPGEOLOCATION_IP2GEO_KEY'),
     ],
 ];

--- a/src/Drivers/IP2GeoDriver.php
+++ b/src/Drivers/IP2GeoDriver.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PulkitJalan\IPGeolocation\Drivers;
+
+use Illuminate\Support\Arr;
+use GuzzleHttp\Client as GuzzleClient;
+
+class IP2GeoDriver extends AbstractIPGeolocationDriver implements IPGeolocationInterface
+{
+    /**
+     * Get array of data using ip2geo.
+     *
+     * @param  string  $ip
+     * @return array
+     */
+    public function get($ip)
+    {
+        $data = $this->getRaw($ip);
+
+        if (empty($data) || ! Arr::get($data, 'success')) {
+            return $this->getDefault();
+        }
+
+        $d = Arr::get($data, 'data', []);
+        $continent = Arr::get($d, 'continent', []);
+        $country = Arr::get($continent, 'country', []);
+        $city = Arr::get($country, 'city', []);
+        $subdivision = Arr::get($country, 'subdivision', []);
+        $timezone = Arr::get($city, 'timezone', []);
+
+        return [
+            'city' => Arr::get($city, 'name'),
+            'country' => Arr::get($country, 'name'),
+            'countryCode' => Arr::get($country, 'code'),
+            'latitude' => Arr::get($city, 'latitude') !== null
+                ? (float) number_format(Arr::get($city, 'latitude'), 5)
+                : null,
+            'longitude' => Arr::get($city, 'longitude') !== null
+                ? (float) number_format(Arr::get($city, 'longitude'), 5)
+                : null,
+            'region' => Arr::get($subdivision, 'name'),
+            'regionCode' => Arr::get($subdivision, 'code'),
+            'timezone' => Arr::get($timezone, 'name'),
+            'postalCode' => Arr::get($city, 'postal_code'),
+        ];
+    }
+
+    /**
+     * Get the raw IPGeolocation info using ip2geo.
+     *
+     * @param  string  $ip
+     * @return array
+     */
+    public function getRaw($ip)
+    {
+        $url = 'https://api.ip2geo.dev/convert?ip=' . urlencode($ip);
+
+        try {
+            return json_decode(
+                $this->guzzle->get($url, [
+                    'headers' => [
+                        'X-Api-Key' => Arr::get($this->config, 'key'),
+                    ],
+                ])->getBody(),
+                true
+            );
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+}

--- a/src/IPGeolocationManager.php
+++ b/src/IPGeolocationManager.php
@@ -5,6 +5,7 @@ namespace PulkitJalan\IPGeolocation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use GuzzleHttp\Client as GuzzleClient;
+use PulkitJalan\IPGeolocation\Drivers\IP2GeoDriver;
 use PulkitJalan\IPGeolocation\Drivers\IPApiDriver;
 use PulkitJalan\IPGeolocation\Drivers\IPInfoDriver;
 use PulkitJalan\IPGeolocation\Drivers\IPQueryDriver;
@@ -103,5 +104,13 @@ class IPGeolocationManager
     protected function createIpqueryDriver(array $data): IPQueryDriver
     {
         return new IPQueryDriver($data, $this->guzzle);
+    }
+
+    /**
+     * Get the ip2geo driver.
+     */
+    protected function createIp2geoDriver(array $data): IP2GeoDriver
+    {
+        return new IP2GeoDriver($data, $this->guzzle);
     }
 }


### PR DESCRIPTION
## Summary

Adds a new driver for the [ip2geo](https://ip2geo.dev) IP geolocation API.

- Supports IPv4 and IPv6 address lookup
- Returns all standard fields: city, country, countryCode, latitude, longitude, region, regionCode, timezone, postalCode
- Full raw API response available via `getRaw()` (includes ASN, currency, flag, continent, etc.)
- Authentication via `X-Api-Key` header
- Graceful error handling (returns defaults on failure)

## Configuration

```php
// config/ip-geolocation.php
'driver' => 'ip2geo',

'ip2geo' => [
    'key' => env('IPGEOLOCATION_IP2GEO_KEY'),
],
```

## Files changed

- **New:** `src/Drivers/IP2GeoDriver.php` — driver implementation
- **Modified:** `src/IPGeolocationManager.php` — added `createIp2geoDriver()` factory method
- **Modified:** `config/ip-geolocation.php` — added ip2geo config section

## Test plan

- [x] `php -l` syntax check passes
- [x] `get('134.201.250.155')` returns normalized data (Los Angeles, CA, 34.0544, -118.244)
- [x] `getRaw()` returns full API response with ASN, currency, etc.
- [x] Bad API key gracefully returns defaults (all null)
- [x] Manager resolves ip2geo driver correctly